### PR TITLE
fix(ntlm8/9): honor host chain_len in precompute kernels (was hardcoded 422000/803000)

### DIFF
--- a/CL/precompute_ntlm8.cl
+++ b/CL/precompute_ntlm8.cl
@@ -9,13 +9,16 @@ __kernel void precompute_ntlm8(
     __global unsigned int *unused4,
     __global unsigned int *unused5,
     __global unsigned int *unused6,
-    __global unsigned long *unused7,
+    __global unsigned long *g_chain_len,
     __global unsigned int *g_device_num,
     __global unsigned int *g_total_devices,
     __global unsigned int *g_exec_block_scaler,
     __global unsigned long *g_output) {
 
-  long target_chain_len = (422000 - *g_device_num) - ((get_global_id(0) + *g_exec_block_scaler) * *g_total_devices) - 1;
+  /* Honor the host's chain_len (arg 7) instead of a hardcoded constant, so
+   * lookups against tables of any chain length crack correctly. */
+  long chain_len = (long)(*g_chain_len);
+  long target_chain_len = (chain_len - *g_device_num) - ((get_global_id(0) + *g_exec_block_scaler) * *g_total_devices) - 1;
 
   if (target_chain_len < 1) {
     g_output[get_global_id(0)] = 0;
@@ -25,7 +28,7 @@ __kernel void precompute_ntlm8(
   unsigned char plaintext[8];
   unsigned long index = hash_char_to_index_ntlm8(g_hash, target_chain_len - 1);
 
-  for(unsigned int i = target_chain_len; i < 421999; i++) {
+  for(unsigned int i = target_chain_len; i < chain_len - 1; i++) {
     index_to_plaintext_ntlm8(index, charset, plaintext);
     index = hash_to_index_ntlm8(hash_ntlm8(plaintext), i);
   }

--- a/CL/precompute_ntlm9.cl
+++ b/CL/precompute_ntlm9.cl
@@ -9,13 +9,15 @@ __kernel void precompute_ntlm9(
     __global unsigned int *unused4,
     __global unsigned int *unused5,
     __global unsigned int *unused6,
-    __global unsigned long *unused7,
+    __global unsigned long *g_chain_len,
     __global unsigned int *g_device_num,
     __global unsigned int *g_total_devices,
     __global unsigned int *g_exec_block_scaler,
     __global unsigned long *g_output) {
 
-  long target_chain_len = (803000 - *g_device_num) - ((get_global_id(0) + *g_exec_block_scaler) * *g_total_devices) - 1;
+  /* Honor the host's chain_len (arg 7) instead of a hardcoded constant. */
+  long chain_len = (long)(*g_chain_len);
+  long target_chain_len = (chain_len - *g_device_num) - ((get_global_id(0) + *g_exec_block_scaler) * *g_total_devices) - 1;
 
   if (target_chain_len < 1) {
     g_output[get_global_id(0)] = 0;
@@ -25,7 +27,7 @@ __kernel void precompute_ntlm9(
   unsigned char plaintext[9];
   unsigned long index = hash_char_to_index_ntlm9(g_hash, target_chain_len - 1);
 
-  for(unsigned int i = target_chain_len; i < 802999; i++) {
+  for(unsigned int i = target_chain_len; i < chain_len - 1; i++) {
     index_to_plaintext_ntlm9(index, plaintext);
     index = hash_to_index_ntlm9(hash_ntlm9(plaintext), i);
   }


### PR DESCRIPTION
## Summary

`CL/precompute_ntlm8.cl` and `CL/precompute_ntlm9.cl` receive the host's `chain_len` at kernel arg slot 7 (`crackalack_lookup.c:977` — `CLCREATEARG(7, chain_len_buffer, ..., sizeof(cl_ulong))`), but the kernels name the buffer `unused7` and ignore it, hardcoding **422000** (NTLM8) and **803000** (NTLM9) for both the initial `target_chain_len` and the forward-walk loop bound.

Because `is_ntlm8()` is chain-length-agnostic (unlike `is_ntlm9()` which gates dispatch to standard-length tables), **NTLM8 lookups against any table where `chain_len != 422000` silently produce false negatives** — precompute walks the wrong number of steps, so real endpoints never match. The NTLM9 case is latent today thanks to `is_ntlm9()`'s gate, but the same footgun should be closed for consistency and future dispatch paths.

## Fix

Both kernels now read `*g_chain_len` at arg slot 7 and loop `i < chain_len - 1`, mirroring `precompute_netntlmv1_7` which was already data-driven. **No host changes needed** — the host has been passing `chain_len` at slot 7 all along.

Minimal diff — just renames `unused7` → `g_chain_len` and swaps two literals per kernel for the variable. No ABI change.

## Verification

Fixed in the bandrel fork at [`b58acf5`](https://github.com/bandrel/rainbowcrackalack/commit/b58acf5), verified on OpenCL/CUDA/Metal:
- Buggy kernels crack **0** known-in-table hashes when the target table has `chain_len=100000`.
- Fixed kernels crack the minted hash.
- All unit tests still pass.

Verification script in the bandrel fork: `scripts/bench/test_ntlm8_nonstandard_chainlen.sh` (generates a `chain_len=100000` NTLM8 table, mints an in-table hash via `gen_known_hash`, asserts it cracks).

## Note

Since issues are disabled on this repo, filing this as a PR directly. Happy to split into two PRs (one per kernel) if preferred.