### PR TITLE
Introduce a GPU backend abstraction (behavior-neutral on OpenCL)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ crackalack_verify
 get_chain
 perfectify
 enumerate_chain
+build/

--- a/crackalack_gen.c
+++ b/crackalack_gen.c
@@ -30,7 +30,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "charset.h"
 #include "clock.h"
@@ -71,7 +71,7 @@
 
 #define ROUND(_x) ((unsigned int)(_x + 0.5))
 
-void write_chains(char *filename, unsigned int chains_per_work_unit, cl_ulong *start_indices, unsigned int start_indices_size, cl_ulong *end_indices, unsigned int end_indices_size, unsigned int thread_id);
+void write_chains(char *filename, unsigned int chains_per_work_unit, gpu_ulong *start_indices, unsigned int start_indices_size, gpu_ulong *end_indices, unsigned int end_indices_size, unsigned int thread_id);
 
 
 struct hash_names {
@@ -87,13 +87,13 @@ struct hash_names valid_hash_names[] = {
 
 /* Struct to represent one GPU device. */
 typedef struct {
-  cl_uint device_number;
-  cl_device_id device;
-  cl_context context;
-  cl_program program;
-  cl_kernel kernel;
-  cl_command_queue queue;
-  cl_uint num_work_units;
+  gpu_uint device_number;
+  gpu_device device;
+  gpu_context context;
+  gpu_program program;
+  gpu_kernel kernel;
+  gpu_queue queue;
+  gpu_uint num_work_units;
 } gpu_dev;
 
 /* Struct to pass arguments to a host thread. */
@@ -208,13 +208,13 @@ void *host_thread(void *ptr) {
   double elapsed = 0;*/
   int err = 0;
 
-  cl_context context = NULL;
-  cl_command_queue queue = NULL;
-  cl_kernel kernel = NULL;
+  gpu_context context = NULL;
+  gpu_queue queue = NULL;
+  gpu_kernel kernel = NULL;
 
-  cl_mem hash_type_buffer = NULL, charset_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, reduction_offset_buffer = NULL, chain_len_buffer = NULL, indices_buffer = NULL, pos_start_buffer = NULL;
+  gpu_buffer hash_type_buffer = NULL, charset_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, reduction_offset_buffer = NULL, chain_len_buffer = NULL, indices_buffer = NULL, pos_start_buffer = NULL;
 
-  cl_uint pos_start = 0;
+  gpu_uint pos_start = 0;
 
   if ((strlen(args->charset) == 0) && (args->charset != NULL)) {
     charset_len = 256;
@@ -288,8 +288,8 @@ void *host_thread(void *ptr) {
 #endif
 
   indices_size = gws;
-  start_indices = calloc(indices_size, sizeof(cl_ulong));
-  end_indices = calloc(indices_size, sizeof(cl_ulong));
+  start_indices = calloc(indices_size, sizeof(gpu_ulong));
+  end_indices = calloc(indices_size, sizeof(gpu_ulong));
   if ((start_indices == NULL) || (end_indices == NULL)) {
     fprintf(stderr, "Failed to create start/end index buffers.\n");
     exit(-1);
@@ -344,16 +344,16 @@ void *host_thread(void *ptr) {
 
     /* Most of the parameters need only be set once upon first invokation. */
     if (hash_type_buffer == NULL) {
-      CLCREATEARG(0, hash_type_buffer, CL_RO, args->hash_type, sizeof(cl_uint));
+      CLCREATEARG(0, hash_type_buffer, CL_RO, args->hash_type, sizeof(gpu_uint));
       //CLCREATEARG_ARRAY(1, charset_buffer, CL_RO, args->charset, strlen(args->charset) + 1);
       CLCREATEARG_ARRAY(1, charset_buffer, CL_RO, args->charset, charset_len + 1);
-      CLCREATEARG(2, plaintext_len_min_buffer, CL_RO, args->plaintext_len_min, sizeof(cl_uint));
-      CLCREATEARG(3, plaintext_len_max_buffer, CL_RO, args->plaintext_len_max, sizeof(cl_uint));
-      CLCREATEARG(4, reduction_offset_buffer, CL_RO, args->reduction_offset, sizeof(cl_uint));
+      CLCREATEARG(2, plaintext_len_min_buffer, CL_RO, args->plaintext_len_min, sizeof(gpu_uint));
+      CLCREATEARG(3, plaintext_len_max_buffer, CL_RO, args->plaintext_len_max, sizeof(gpu_uint));
+      CLCREATEARG(4, reduction_offset_buffer, CL_RO, args->reduction_offset, sizeof(gpu_uint));
     }
 
     /* The start_indices parameter must be set each block.  The start indices are loaded into this read/write buffer, and the end indices will be in it when finished. */
-    CLCREATEARG_ARRAY(6, indices_buffer, CL_RW, start_indices, indices_size * sizeof(cl_ulong));
+    CLCREATEARG_ARRAY(6, indices_buffer, CL_RW, start_indices, indices_size * sizeof(gpu_ulong));
 
     /* If the chain length is greater than MAX_CHAIN_LEN, then the chains must be computed in multiple passes (otherwise Windows drivers crash). */
     for (pass = 0; pass < num_passes; pass++) {
@@ -367,8 +367,8 @@ void *host_thread(void *ptr) {
       pos_start = pass * MAX_CHAIN_LEN;
 
       /*printf("Pass #%u: pos_start: %u; chain_len: %u\n", pass, pos_start, chain_len);*/
-      CLCREATEARG(5, chain_len_buffer, CL_RO, chain_len, sizeof(cl_uint));
-      CLCREATEARG(7, pos_start_buffer, CL_RO, pos_start, sizeof(cl_uint));
+      CLCREATEARG(5, chain_len_buffer, CL_RO, chain_len, sizeof(gpu_uint));
+      CLCREATEARG(7, pos_start_buffer, CL_RO, pos_start, sizeof(gpu_uint));
 
       /* For AMD GPUs, ensure that all kernels are running concurrently.  This is a
        * requirement for the closed-source Windows driver, and may or may not be
@@ -395,7 +395,7 @@ void *host_thread(void *ptr) {
     }
 
     /* Get the kernel output. */
-    CLREADBUFFER(indices_buffer, indices_size * sizeof(cl_ulong), end_indices);
+    CLREADBUFFER(indices_buffer, indices_size * sizeof(gpu_ulong), end_indices);
     CLFREEBUFFER(indices_buffer);
 
     /* If we are in benchmark mode, don't loop again, nor write to the output file. */
@@ -418,10 +418,10 @@ void *host_thread(void *ptr) {
 
 
 /* Writes the chains given by the kernel to the file. */
-void write_chains(char *filename, unsigned int chains_per_work_unit, cl_ulong *start_indices, unsigned int start_indices_size, cl_ulong *end_indices, unsigned int end_indices_size, unsigned int thread_id) {
+void write_chains(char *filename, unsigned int chains_per_work_unit, gpu_ulong *start_indices, unsigned int start_indices_size, gpu_ulong *end_indices, unsigned int end_indices_size, unsigned int thread_id) {
   int i = 0, j = 0;
   unsigned int file_size = 0;
-  cl_ulong start = 0;
+  gpu_ulong start = 0;
   rc_file f = rc_fopen(filename, 0), l = NULL;
   char log_filename[256] = {0};
   int empty_chains = 0;
@@ -481,8 +481,8 @@ void write_chains(char *filename, unsigned int chains_per_work_unit, cl_ulong *s
   for (i = 0; i < start_indices_size; i++) {
     start = start_indices[i];
     for (j = (i * chains_per_work_unit); (j < ((i * chains_per_work_unit) + chains_per_work_unit)) && (j < end_indices_size); j++) {
-      rc_fwrite(&start, sizeof(cl_ulong), 1, f);
-      rc_fwrite(&(end_indices[j]), sizeof(cl_ulong), 1, f);
+      rc_fwrite(&start, sizeof(gpu_ulong), 1, f);
+      rc_fwrite(&(end_indices[j]), sizeof(gpu_ulong), 1, f);
       start++;
     }
   }
@@ -497,8 +497,8 @@ void write_chains(char *filename, unsigned int chains_per_work_unit, cl_ulong *s
 
 
 int main(int ac, char **av) {
-  cl_platform_id platforms[MAX_NUM_PLATFORMS] = {0};
-  cl_device_id devices[MAX_NUM_DEVICES] = {0};
+  gpu_platform platforms[MAX_NUM_PLATFORMS] = {0};
+  gpu_device devices[MAX_NUM_DEVICES] = {0};
   pthread_t threads[MAX_NUM_DEVICES] = {0};
   char filename[256] = {0}, time_str[128] = {0};
 
@@ -508,7 +508,7 @@ int main(int ac, char **av) {
   char *hash_name = NULL, *charset_name = NULL, *charset = NULL;
   unsigned int plaintext_len_min = 0, plaintext_len_max = 0, total_chains_in_table = 0, table_index = 0, benchmark_mode = 0;
   unsigned int resuming_table = 0;  /* Set when a table gen is being resumed. */
-  cl_uint hash_type = 0, chain_len = 0, num_platforms = 0, num_devices = 0;
+  gpu_uint hash_type = 0, chain_len = 0, num_platforms = 0, num_devices = 0;
   uint64_t part_index = 0;
   int i = 0;
   int charset_len = 0;

--- a/crackalack_gen.c
+++ b/crackalack_gen.c
@@ -840,7 +840,7 @@ int main(int ac, char **av) {
   }
 
   for (i = 0; i < num_devices; i++)
-    rc_clReleaseDevice(devices[i]);
+    gpu_release_device(devices[i]);
 
   pthread_barrier_destroy(&barrier);
   FREE(args);

--- a/crackalack_lookup.c
+++ b/crackalack_lookup.c
@@ -38,7 +38,7 @@
 #include <sys/stat.h>
 #include <time.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "charset.h"
 #include "clock.h"
@@ -71,10 +71,10 @@
 struct _precomputed_and_potential_indices {
   char *username;  /* Non-NULL if loaded file format is pwdump. */
   char *hash;
-  cl_ulong *precomputed_end_indices;
-  cl_uint num_precomputed_end_indices;
+  gpu_ulong *precomputed_end_indices;
+  gpu_uint num_precomputed_end_indices;
 
-  cl_ulong *potential_start_indices;
+  gpu_ulong *potential_start_indices;
   unsigned int num_potential_start_indices;
   unsigned int potential_start_indices_size;
   unsigned int *potential_start_index_positions; /* Buffer size is always num_potential_start_indices. */
@@ -88,13 +88,13 @@ typedef struct _precomputed_and_potential_indices precomputed_and_potential_indi
 
 /* Struct to represent one GPU device. */
 typedef struct {
-  cl_uint device_number;
-  cl_device_id device;
-  cl_context context;
-  cl_program program;
-  cl_kernel kernel;
-  cl_command_queue queue;
-  cl_uint num_work_units;
+  gpu_uint device_number;
+  gpu_device device;
+  gpu_context context;
+  gpu_program program;
+  gpu_kernel kernel;
+  gpu_queue queue;
+  gpu_uint num_work_units;
 } gpu_dev;
 
 
@@ -116,14 +116,14 @@ typedef struct {
   uint64_t *results;
   unsigned int num_results;
 
-  cl_ulong *potential_start_indices;
+  gpu_ulong *potential_start_indices;
   unsigned int num_potential_start_indices;
   
   /* Buffer size is always num_potential_start_indices. */
   unsigned int *potential_start_index_positions;
   
   /* Length is always num_potential_start_indices. */
-  cl_ulong *hash_base_indices;
+  gpu_ulong *hash_base_indices;
 
   gpu_dev gpu;
 } thread_args;
@@ -131,7 +131,7 @@ typedef struct {
 
 /* Struct to pass to binary search threads. */
 typedef struct {
-  cl_ulong *rainbow_table;
+  gpu_ulong *rainbow_table;
   unsigned int num_chains;
   precomputed_and_potential_indices *ppi_head;
   unsigned int thread_number;
@@ -142,7 +142,7 @@ typedef struct {
 /* Struct to hold node in linked list of preloaded tables. */
 struct _preloaded_table {
   char *filepath;
-  cl_ulong *rainbow_table;
+  gpu_ulong *rainbow_table;
   unsigned int num_chains;
   struct _preloaded_table *next;
 };
@@ -159,7 +159,7 @@ void free_loaded_hashes(char **usernames, char **hashes);
 void *host_thread_false_alarm(void *ptr);
 void *preloading_thread(void *ptr);
 void print_eta_precompute();
-cl_ulong *search_precompute_cache(char *index_data, unsigned int *num_indices, char *filename, unsigned int filename_size);
+gpu_ulong *search_precompute_cache(char *index_data, unsigned int *num_indices, char *filename, unsigned int filename_size);
 void search_tables(unsigned int total_tables, precomputed_and_potential_indices *ppi, thread_args *args);
 void save_cracked_hash(precomputed_and_potential_indices *ppi, unsigned int hash_type);
 
@@ -200,7 +200,7 @@ size_t user_provided_gws = 0;
 int disable_platform = -1;
 
 /* The total number of precomputed indices loaded into memory.  Each one of these is
- * a cl_ulong (8 bytes). */
+ * a gpu_ulong (8 bytes). */
 uint64_t total_precomputed_indices_loaded = 0;
 
 /* Set to 1 if the NTLM8/9 message was printed.  This prevents console spam. */
@@ -258,15 +258,15 @@ unsigned int num_hashes_precomputed_total = 0;
 
 /* Adds a potential start index (and position within the chain) to check for false
  * alarms. */
-void add_potential_start_index_and_position(precomputed_and_potential_indices *ppi, cl_ulong start, unsigned int position) {
+void add_potential_start_index_and_position(precomputed_and_potential_indices *ppi, gpu_ulong start, unsigned int position) {
   #define POTENTIAL_START_INDICES_INITIAL_SIZE 16
 
   LOCK_PPI();
 
   /* Initialize the potential_start_indices buffer if it isn't already. */
   if (ppi->potential_start_indices == NULL) {
-    ppi->potential_start_indices = calloc(POTENTIAL_START_INDICES_INITIAL_SIZE, sizeof(cl_ulong));
-    ppi->potential_start_index_positions = calloc(POTENTIAL_START_INDICES_INITIAL_SIZE, sizeof(cl_ulong));
+    ppi->potential_start_indices = calloc(POTENTIAL_START_INDICES_INITIAL_SIZE, sizeof(gpu_ulong));
+    ppi->potential_start_index_positions = calloc(POTENTIAL_START_INDICES_INITIAL_SIZE, sizeof(gpu_ulong));
     if ((ppi->potential_start_indices == NULL) || (ppi->potential_start_index_positions == NULL)) {
       fprintf(stderr, "Failed to initialize potential_start_indices / potential_start_index_positions buffer.\n");
       exit(-1);
@@ -279,8 +279,8 @@ void add_potential_start_index_and_position(precomputed_and_potential_indices *p
     unsigned int new_size_in_ulongs = ppi->potential_start_indices_size * 2;
 
     /*printf("Resizing array from %u to %u.\n", ppi->potential_start_indices_size, new_size_in_ulongs);*/
-    ppi->potential_start_indices = recalloc(ppi->potential_start_indices, new_size_in_ulongs * sizeof(cl_ulong), ppi->potential_start_indices_size * sizeof(cl_ulong));
-    ppi->potential_start_index_positions = recalloc(ppi->potential_start_index_positions, new_size_in_ulongs * sizeof(cl_ulong), ppi->potential_start_indices_size * sizeof(cl_ulong));
+    ppi->potential_start_indices = recalloc(ppi->potential_start_indices, new_size_in_ulongs * sizeof(gpu_ulong), ppi->potential_start_indices_size * sizeof(gpu_ulong));
+    ppi->potential_start_index_positions = recalloc(ppi->potential_start_index_positions, new_size_in_ulongs * sizeof(gpu_ulong), ppi->potential_start_indices_size * sizeof(gpu_ulong));
     if ((ppi->potential_start_indices == NULL) || (ppi->potential_start_index_positions == NULL)) {
       fprintf(stderr, "Failed to re-allocate potential_start_indices/potential_start_index_positions buffer to %u.\n", new_size_in_ulongs);
       exit(-1);
@@ -299,15 +299,15 @@ void check_false_alarms(precomputed_and_potential_indices *ppi, thread_args *arg
   pthread_t threads[MAX_NUM_DEVICES] = {0};
   char time_str[128] = {0};
   struct timespec start_time = {0};
-  cl_ulong plaintext_space_up_to_index[MAX_PLAINTEXT_LEN] = {0};
+  gpu_ulong plaintext_space_up_to_index[MAX_PLAINTEXT_LEN] = {0};
 
   unsigned int num_potential_start_indices = 0, i = 0, j = 0; // init to -1 since 0 is possible index
   unsigned int total_devices = args[0].total_devices;
-  cl_ulong plaintext_space_total = 0;
+  gpu_ulong plaintext_space_total = 0;
   double time_delta = 0.0;
 
   precomputed_and_potential_indices *ppi_cur = ppi;
-  cl_ulong *potential_start_indices = NULL, *hash_base_indices = NULL;
+  gpu_ulong *potential_start_indices = NULL, *hash_base_indices = NULL;
   unsigned int *potential_start_index_positions = NULL;
   precomputed_and_potential_indices **ppi_refs = NULL;
 
@@ -327,9 +327,9 @@ void check_false_alarms(precomputed_and_potential_indices *ppi, thread_args *arg
   num_falsealarms += num_potential_start_indices;
 
   /* Allocate a buffer to hold them all. */
-  potential_start_indices = calloc(num_potential_start_indices, sizeof(cl_ulong));
-  potential_start_index_positions = calloc(num_potential_start_indices, sizeof(cl_ulong));
-  hash_base_indices = calloc(num_potential_start_indices, sizeof(cl_ulong));
+  potential_start_indices = calloc(num_potential_start_indices, sizeof(gpu_ulong));
+  potential_start_index_positions = calloc(num_potential_start_indices, sizeof(gpu_ulong));
+  hash_base_indices = calloc(num_potential_start_indices, sizeof(gpu_ulong));
   ppi_refs = calloc(num_potential_start_indices, sizeof(precomputed_and_potential_indices *));
   if ((potential_start_indices == NULL) || (potential_start_index_positions == NULL) || (hash_base_indices == NULL) || (ppi_refs == NULL)) {
     fprintf(stderr, "Error while creating buffer for potential start indices/positions/hash indices/ppi refs.\n");
@@ -350,7 +350,7 @@ void check_false_alarms(precomputed_and_potential_indices *ppi, thread_args *arg
   while(ppi_cur) {
     unsigned char hash[MAX_HASH_OUTPUT_LEN] = {0};
     unsigned int hash_len = hex_to_bytes(ppi_cur->hash, sizeof(hash), hash);
-    cl_ulong hash_base_index = hash_to_index(hash, hash_len, args->reduction_offset, plaintext_space_total, 0);  /* We always use position 0 here.  When the GPU code is comparing indices, it will add in the current position. */
+    gpu_ulong hash_base_index = hash_to_index(hash, hash_len, args->reduction_offset, plaintext_space_total, 0);  /* We always use position 0 here.  When the GPU code is comparing indices, it will add in the current position. */
 
 
     if (ppi_cur->plaintext == NULL) {
@@ -493,7 +493,7 @@ void check_memory_usage() {
   if (total_memory == 0)
     return;
 
-  num_precompute_bytes = total_precomputed_indices_loaded * sizeof(cl_ulong);
+  num_precompute_bytes = total_precomputed_indices_loaded * sizeof(gpu_ulong);
   percent_memory_used = ((double)num_precompute_bytes / (double)total_memory) * 100;
   if (percent_memory_used > 65) {
     printf("\n\n\n\t!! WARNING !!\n\n\tThe pre-computed indices take up more than 65%% of total RAM!  This may result in strange failures from clFinish() and other OpenCL functions.  If this happens, either run this lookup with a smaller number of hashes at a time, or do it on a machine with more memory.\n\n\tMemory used by pre-compute indices: %"QUOTE PRIu64"\n\tTotal RAM: %"QUOTE PRIu64"\n\tPercent used: %.1f%%\n\n\n\n", num_precompute_bytes, total_memory, percent_memory_used);
@@ -682,23 +682,23 @@ unsigned int get_num_cpu_cores() {
 void *host_thread_false_alarm(void *ptr) {
   thread_args *args = (thread_args *)ptr;
   gpu_dev *gpu = &(args->gpu);
-  cl_context context = NULL;
-  cl_command_queue queue = NULL;
-  cl_kernel kernel = NULL;
+  gpu_context context = NULL;
+  gpu_queue queue = NULL;
+  gpu_kernel kernel = NULL;
   int err = 0;
   char *kernel_path = FALSE_ALARM_KERNEL_PATH, *kernel_name = "false_alarm_check";
 
-  cl_mem hash_type_buffer = NULL, charset_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, reduction_offset_buffer = NULL, plaintext_space_total_buffer = NULL, plaintext_space_up_to_index_buffer = NULL, device_num_buffer = NULL, total_devices_buffer = NULL, num_start_indices_buffer = NULL, start_indices_buffer = NULL, start_index_positions_buffer = NULL, hash_base_indices_buffer = NULL, output_block_buffer = NULL, exec_block_scaler_buffer = NULL;
-  /*cl_mem debug_ulong_buffer = NULL;*/
+  gpu_buffer hash_type_buffer = NULL, charset_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, reduction_offset_buffer = NULL, plaintext_space_total_buffer = NULL, plaintext_space_up_to_index_buffer = NULL, device_num_buffer = NULL, total_devices_buffer = NULL, num_start_indices_buffer = NULL, start_indices_buffer = NULL, start_index_positions_buffer = NULL, hash_base_indices_buffer = NULL, output_block_buffer = NULL, exec_block_scaler_buffer = NULL;
+  /*gpu_buffer debug_ulong_buffer = NULL;*/
 
-  cl_ulong *start_indices = NULL, *hash_base_indices = NULL, *plaintext_indices = NULL, *output_block = NULL;
+  gpu_ulong *start_indices = NULL, *hash_base_indices = NULL, *plaintext_indices = NULL, *output_block = NULL;
   unsigned int *start_index_positions = NULL;
 
   unsigned int num_start_indices = 0, num_start_index_positions = 0, num_hash_base_indices = 0, num_plaintext_indices = 0, num_exec_blocks = 0, output_block_len = 0, exec_block = 0, output_block_index = 0, plaintext_indicies_index = 0;
   uint64_t plaintext_space_total = 0;
-  cl_ulong plaintext_space_up_to_index[MAX_PLAINTEXT_LEN] = {0};
+  gpu_ulong plaintext_space_up_to_index[MAX_PLAINTEXT_LEN] = {0};
   size_t gws = 0, kernel_work_group_size = 0, kernel_preferred_work_group_size_multiple = 0;
-  /*cl_ulong debug_ulong[128] = {0};*/
+  /*gpu_ulong debug_ulong[128] = {0};*/
   int charset_len = 0;
   if (strcmp(args->charset_name, "byte") == 0) {
     charset_len = 256;
@@ -715,7 +715,7 @@ void *host_thread_false_alarm(void *ptr) {
   start_index_positions = args->potential_start_index_positions;
   hash_base_indices = args->hash_base_indices;
 
-  plaintext_indices = calloc(num_plaintext_indices, sizeof(cl_ulong));
+  plaintext_indices = calloc(num_plaintext_indices, sizeof(gpu_ulong));
   if (plaintext_indices == NULL) {
     fprintf(stderr, "Error while allocating buffers.\n");
     exit(-1);
@@ -795,31 +795,31 @@ void *host_thread_false_alarm(void *ptr) {
   //printf("num_exec_blocks: %d, num_start_indices: %d\n", num_exec_blocks, num_start_indices);
 
   output_block_len = gws;
-  output_block = calloc(output_block_len, sizeof(cl_ulong));
+  output_block = calloc(output_block_len, sizeof(gpu_ulong));
   if (output_block == NULL) {
     fprintf(stderr, "Error while allocating output buffer(s).\n");
     exit(-1);
   }
 
-  CLCREATEARG(0, hash_type_buffer, CL_RO, args->hash_type, sizeof(cl_uint));
+  CLCREATEARG(0, hash_type_buffer, CL_RO, args->hash_type, sizeof(gpu_uint));
   CLCREATEARG_ARRAY(1, charset_buffer, CL_RO, args->charset, charset_len);
-  CLCREATEARG(2, plaintext_len_min_buffer, CL_RO, args->plaintext_len_min, sizeof(cl_uint));
-  CLCREATEARG(3, plaintext_len_max_buffer, CL_RO, args->plaintext_len_max, sizeof(cl_uint));
-  CLCREATEARG(4, reduction_offset_buffer, CL_RO, args->reduction_offset, sizeof(cl_uint));
-  CLCREATEARG(5, plaintext_space_total_buffer, CL_RO, plaintext_space_total, sizeof(cl_ulong));
-  CLCREATEARG_ARRAY(6, plaintext_space_up_to_index_buffer, CL_RO, plaintext_space_up_to_index, MAX_PLAINTEXT_LEN * sizeof(cl_ulong));
-  CLCREATEARG(7, device_num_buffer, CL_RO, gpu->device_number, sizeof(cl_uint));
-  CLCREATEARG(8, total_devices_buffer, CL_RO, args->total_devices, sizeof(cl_uint));
-  CLCREATEARG(9, num_start_indices_buffer, CL_RO, num_start_indices, sizeof(cl_uint));
-  CLCREATEARG_ARRAY(10, start_indices_buffer, CL_RO, start_indices, num_start_indices * sizeof(cl_ulong));
+  CLCREATEARG(2, plaintext_len_min_buffer, CL_RO, args->plaintext_len_min, sizeof(gpu_uint));
+  CLCREATEARG(3, plaintext_len_max_buffer, CL_RO, args->plaintext_len_max, sizeof(gpu_uint));
+  CLCREATEARG(4, reduction_offset_buffer, CL_RO, args->reduction_offset, sizeof(gpu_uint));
+  CLCREATEARG(5, plaintext_space_total_buffer, CL_RO, plaintext_space_total, sizeof(gpu_ulong));
+  CLCREATEARG_ARRAY(6, plaintext_space_up_to_index_buffer, CL_RO, plaintext_space_up_to_index, MAX_PLAINTEXT_LEN * sizeof(gpu_ulong));
+  CLCREATEARG(7, device_num_buffer, CL_RO, gpu->device_number, sizeof(gpu_uint));
+  CLCREATEARG(8, total_devices_buffer, CL_RO, args->total_devices, sizeof(gpu_uint));
+  CLCREATEARG(9, num_start_indices_buffer, CL_RO, num_start_indices, sizeof(gpu_uint));
+  CLCREATEARG_ARRAY(10, start_indices_buffer, CL_RO, start_indices, num_start_indices * sizeof(gpu_ulong));
   CLCREATEARG_ARRAY(11, start_index_positions_buffer, CL_RO, start_index_positions, num_start_index_positions * sizeof(unsigned int));
-  CLCREATEARG_ARRAY(12, hash_base_indices_buffer, CL_RO, hash_base_indices, num_hash_base_indices * sizeof(cl_ulong));
-  CLCREATEARG_ARRAY(14, output_block_buffer, CL_WO, output_block, output_block_len * sizeof(cl_ulong));
+  CLCREATEARG_ARRAY(12, hash_base_indices_buffer, CL_RO, hash_base_indices, num_hash_base_indices * sizeof(gpu_ulong));
+  CLCREATEARG_ARRAY(14, output_block_buffer, CL_WO, output_block, output_block_len * sizeof(gpu_ulong));
 
   for (exec_block = 0; exec_block < num_exec_blocks; exec_block++) {
     unsigned int exec_block_scaler = exec_block * gws;
 
-    CLCREATEARG(13, exec_block_scaler_buffer, CL_RO, exec_block_scaler, sizeof(cl_uint));
+    CLCREATEARG(13, exec_block_scaler_buffer, CL_RO, exec_block_scaler, sizeof(gpu_uint));
 
     if (is_amd_gpu) {
       int barrier_ret = pthread_barrier_wait(&barrier);
@@ -835,7 +835,7 @@ void *host_thread_false_alarm(void *ptr) {
     CLWAIT(gpu->queue);
 
     /* Read the results. */
-    CLREADBUFFER(output_block_buffer, output_block_len * sizeof(cl_ulong), output_block);
+    CLREADBUFFER(output_block_buffer, output_block_len * sizeof(gpu_ulong), output_block);
 
     output_block_index = 0;
     while ((plaintext_indicies_index < num_plaintext_indices) && (output_block_index < output_block_len))
@@ -879,21 +879,21 @@ void *host_thread_false_alarm(void *ptr) {
 void *host_thread_precompute(void *ptr) {
   thread_args *args = (thread_args *)ptr;
   gpu_dev *gpu = &(args->gpu);
-  cl_context context = NULL;
-  cl_command_queue queue = NULL;
-  cl_kernel kernel = NULL;
+  gpu_context context = NULL;
+  gpu_queue queue = NULL;
+  gpu_kernel kernel = NULL;
   int err = 0;
   char *kernel_path = PRECOMPUTE_KERNEL_PATH, *kernel_name = "precompute";
 
-  cl_mem hash_type_buffer = NULL, hash_buffer = NULL, hash_len_buffer = NULL, charset_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, table_index_buffer = NULL, chain_len_buffer = NULL, device_num_buffer = NULL, total_devices_buffer = NULL, exec_block_scaler_buffer = NULL, output_block_buffer = NULL/*, debug_buffer = NULL*/;
+  gpu_buffer hash_type_buffer = NULL, hash_buffer = NULL, hash_len_buffer = NULL, charset_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, table_index_buffer = NULL, chain_len_buffer = NULL, device_num_buffer = NULL, total_devices_buffer = NULL, exec_block_scaler_buffer = NULL, output_block_buffer = NULL/*, debug_buffer = NULL*/;
 
   size_t gws = 0;
-  cl_ulong *output = NULL, *output_block = NULL;
+  gpu_ulong *output = NULL, *output_block = NULL;
   unsigned int output_len = 0, output_block_len = 0, num_exec_blocks = 0, exec_block = 0, output_index = 0, output_block_index = 0;
   /*unsigned int i = 0;*/
 
   unsigned char hash_binary[32] = {0};
-  cl_uint hash_binary_len = 0;
+  gpu_uint hash_binary_len = 0;
 
 
   /* Convert the hash from a hex string to bytes.*/
@@ -957,11 +957,11 @@ void *host_thread_precompute(void *ptr) {
   /*printf("Host thread #%u started; GWS: %zu.\n", gpu->device_number, gws);*/
 
   /* This will hold the results from this one GPU. */
-  output = calloc(output_len, sizeof(cl_ulong));
+  output = calloc(output_len, sizeof(gpu_ulong));
 
   /* Holds the results from one kernel exec. */
   output_block_len = gws;
-  output_block = calloc(output_block_len, sizeof(cl_ulong));
+  output_block = calloc(output_block_len, sizeof(gpu_ulong));
 
   if ((output == NULL) || (output_block == NULL)) {
     fprintf(stderr, "Error while allocating output buffer(s).\n");
@@ -980,24 +980,24 @@ void *host_thread_precompute(void *ptr) {
   }
 
 
-  CLCREATEARG(0, hash_type_buffer, CL_RO, args->hash_type, sizeof(cl_uint));
+  CLCREATEARG(0, hash_type_buffer, CL_RO, args->hash_type, sizeof(gpu_uint));
   CLCREATEARG_ARRAY(1, hash_buffer, CL_RO, hash_binary, hash_binary_len);
-  CLCREATEARG(2, hash_len_buffer, CL_RO, hash_binary_len, sizeof(cl_uint));
+  CLCREATEARG(2, hash_len_buffer, CL_RO, hash_binary_len, sizeof(gpu_uint));
   CLCREATEARG_ARRAY(3, charset_buffer, CL_RO, args->charset, charset_len);
-  CLCREATEARG(4, plaintext_len_min_buffer, CL_RO, args->plaintext_len_min, sizeof(cl_uint));
-  CLCREATEARG(5, plaintext_len_max_buffer, CL_RO, args->plaintext_len_max, sizeof(cl_uint));
-  CLCREATEARG(6, table_index_buffer, CL_RO, args->table_index, sizeof(cl_uint));
-  CLCREATEARG(7, chain_len_buffer, CL_RO, args->chain_len, sizeof(cl_ulong));
-  CLCREATEARG(8, device_num_buffer, CL_RO, gpu->device_number, sizeof(cl_uint));
-  CLCREATEARG(9, total_devices_buffer, CL_RO, args->total_devices, sizeof(cl_uint));
-  CLCREATEARG_ARRAY(11, output_block_buffer, CL_WO, output_block, output_block_len * sizeof(cl_ulong));
+  CLCREATEARG(4, plaintext_len_min_buffer, CL_RO, args->plaintext_len_min, sizeof(gpu_uint));
+  CLCREATEARG(5, plaintext_len_max_buffer, CL_RO, args->plaintext_len_max, sizeof(gpu_uint));
+  CLCREATEARG(6, table_index_buffer, CL_RO, args->table_index, sizeof(gpu_uint));
+  CLCREATEARG(7, chain_len_buffer, CL_RO, args->chain_len, sizeof(gpu_ulong));
+  CLCREATEARG(8, device_num_buffer, CL_RO, gpu->device_number, sizeof(gpu_uint));
+  CLCREATEARG(9, total_devices_buffer, CL_RO, args->total_devices, sizeof(gpu_uint));
+  CLCREATEARG_ARRAY(11, output_block_buffer, CL_WO, output_block, output_block_len * sizeof(gpu_ulong));
   /*CLCREATEARG_DEBUG(9, debug_buffer, debug_ptr);*/
 
   for (exec_block = 0; exec_block < num_exec_blocks; exec_block++) {
     unsigned int exec_block_scaler = exec_block * gws;
 
 
-    CLCREATEARG(10, exec_block_scaler_buffer, CL_RO, exec_block_scaler, sizeof(cl_uint));
+    CLCREATEARG(10, exec_block_scaler_buffer, CL_RO, exec_block_scaler, sizeof(gpu_uint));
 
     if (is_amd_gpu) {
       int barrier_ret = pthread_barrier_wait(&barrier);
@@ -1013,7 +1013,7 @@ void *host_thread_precompute(void *ptr) {
     CLWAIT(gpu->queue);
 
     /* Read the results. */
-    CLREADBUFFER(output_block_buffer, output_block_len * sizeof(cl_ulong), output_block);
+    CLREADBUFFER(output_block_buffer, output_block_len * sizeof(gpu_ulong), output_block);
 
     /* Append this block out output to the total output for this GPU. */
     output_block_index = 0;
@@ -1198,10 +1198,10 @@ void precompute_hash(unsigned int num_devices, thread_args *args, precomputed_an
     /* Ok, so it turns out that we generated the array backwards.  Oh well.  We will
      * just iterate backwards here to compensate. */
     /*for (k = output_index - 1; k >= 0; k--)
-      fwrite(&(output[k]), sizeof(cl_ulong), 1, f);*/
+      fwrite(&(output[k]), sizeof(gpu_ulong), 1, f);*/
 
     for (k = 0; k < output_index; k++)
-      fwrite(&(output[k]), sizeof(cl_ulong), 1, f);
+      fwrite(&(output[k]), sizeof(gpu_ulong), 1, f);
 
     FCLOSE(f);
 
@@ -1261,7 +1261,7 @@ void precompute_hash(unsigned int num_devices, thread_args *args, precomputed_an
   ppi->hash = args->hash;
   ppi->num_precomputed_end_indices = output_index;
 
-  ppi->precomputed_end_indices = calloc(ppi->num_precomputed_end_indices, sizeof(cl_ulong));
+  ppi->precomputed_end_indices = calloc(ppi->num_precomputed_end_indices, sizeof(gpu_ulong));
   if (ppi->precomputed_end_indices == NULL) {
     fprintf(stderr, "Error allocating index buffer for precomputed indices.\n");
     exit(-1);
@@ -1303,7 +1303,7 @@ void _preloading_thread(char *rt_dir) {
 
     /* If this is a compressed or uncompressed rainbow table, load it! */
     } else if (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc") || str_ends_with(de->d_name, ".rt.rar") || str_ends_with(de->d_name, ".rtc.rar")) {
-      cl_ulong *rainbow_table = NULL;
+      gpu_ulong *rainbow_table = NULL;
       unsigned int num_chains = 0, is_uncompressed_table = 0;
       struct timespec start_time_io = {0};
 
@@ -1335,16 +1335,16 @@ void _preloading_thread(char *rt_dir) {
 	if (f != NULL) {
 	  long file_size = get_file_size(f);
 
-	  if ((file_size % (sizeof(cl_ulong) * 2) == 0) && (file_size > 0)) {
-	    unsigned int num_longs = file_size / sizeof(cl_ulong);
+	  if ((file_size % (sizeof(gpu_ulong) * 2) == 0) && (file_size > 0)) {
+	    unsigned int num_longs = file_size / sizeof(gpu_ulong);
 
-	    rainbow_table = calloc(num_longs, sizeof(cl_ulong));
+	    rainbow_table = calloc(num_longs, sizeof(gpu_ulong));
 	    if (rainbow_table == NULL) {
-	      fprintf(stderr, "Failed to allocate %"PRIu64" bytes for rainbow table!: %s\n", num_longs * sizeof(cl_ulong), filepath);
+	      fprintf(stderr, "Failed to allocate %"PRIu64" bytes for rainbow table!: %s\n", num_longs * sizeof(gpu_ulong), filepath);
 	      exit(-1);
 	    }
 
-	    if (fread(rainbow_table, sizeof(cl_ulong), num_longs, f) != num_longs) {
+	    if (fread(rainbow_table, sizeof(gpu_ulong), num_longs, f) != num_longs) {
 	      fprintf(stderr, "Error while reading rainbow table: %s\n", strerror(errno));
 	      exit(-1);
 	    }
@@ -1352,7 +1352,7 @@ void _preloading_thread(char *rt_dir) {
 	    time_io += get_elapsed(&start_time_io);
 	    num_chains = num_longs / 2;
 	  } else
-	    fprintf(stderr, "Rainbow table size is not a multiple of %"PRIu64": %ld\n", sizeof(cl_ulong) * 2, file_size);
+	    fprintf(stderr, "Rainbow table size is not a multiple of %"PRIu64": %ld\n", sizeof(gpu_ulong) * 2, file_size);
 
 	  FCLOSE(f);
 	} else
@@ -1499,7 +1499,7 @@ void print_usage_and_exit(char *prog_name, int exit_code) {
 
 
 /* Helper function for rt_binary_search(). */
-unsigned int _rt_binary_search(cl_ulong *rainbow_table, unsigned int low, unsigned int high, cl_ulong search_index, cl_ulong *start) {
+unsigned int _rt_binary_search(gpu_ulong *rainbow_table, unsigned int low, unsigned int high, gpu_ulong search_index, gpu_ulong *start) {
   unsigned int chain = 0;
 
 
@@ -1528,7 +1528,7 @@ void *rt_binary_search_thread(void *ptr) {
   search_thread_args *args = (search_thread_args *)ptr;
   precomputed_and_potential_indices *ppi_cur = args->ppi_head;
   unsigned int i = 0;
-  cl_ulong start = 0;
+  gpu_ulong start = 0;
 
 
   while (ppi_cur != NULL) {
@@ -1551,7 +1551,7 @@ void *rt_binary_search_thread(void *ptr) {
  * precomputed end indices.  If/when matches are found, the corresponding start indices
  * are added to the precomputed_and_potential_indices's potential_start_indices
  * array. */
-void rt_binary_search(cl_ulong *rainbow_table, unsigned int num_chains, precomputed_and_potential_indices *ppi_head) {
+void rt_binary_search(gpu_ulong *rainbow_table, unsigned int num_chains, precomputed_and_potential_indices *ppi_head) {
   struct timespec start_time_searching = {0};
   char time_searching_str[64] = {0};
   unsigned int num_threads = get_num_cpu_cores();
@@ -1688,13 +1688,13 @@ void save_cracked_hash(precomputed_and_potential_indices *ppi, unsigned int hash
 /* Searches the precompute cache for matching index data.  If found, an array of
  * indices is returned, num_indices set to the array size, and the filename buffer
  * is set to the *.index cache file. */
-cl_ulong *search_precompute_cache(char *index_data, unsigned int *num_indices, char *filename, unsigned int filename_size) {
+gpu_ulong *search_precompute_cache(char *index_data, unsigned int *num_indices, char *filename, unsigned int filename_size) {
   char buf[256] = {0};
   int file_size = 0;
   DIR *d = NULL;
   struct dirent *de = NULL;
   FILE *f = NULL;
-  cl_ulong *ret = NULL;
+  gpu_ulong *ret = NULL;
 
 
   *num_indices = 0;
@@ -1745,20 +1745,20 @@ cl_ulong *search_precompute_cache(char *index_data, unsigned int *num_indices, c
 
 	file_size = get_file_size(f);
 
-	if (file_size % sizeof(cl_ulong) != 0) {
-	  fprintf(stderr, "Precomputed indices file is not a multiple of %"PRIu64": %u\n", sizeof(cl_ulong), file_size);
+	if (file_size % sizeof(gpu_ulong) != 0) {
+	  fprintf(stderr, "Precomputed indices file is not a multiple of %"PRIu64": %u\n", sizeof(gpu_ulong), file_size);
 	  exit(-1);
 	}
 
-	*num_indices = file_size / sizeof(cl_ulong);
+	*num_indices = file_size / sizeof(gpu_ulong);
 
-	ret = calloc(*num_indices, sizeof(cl_ulong));
+	ret = calloc(*num_indices, sizeof(gpu_ulong));
 	if (ret == NULL) {
 	  fprintf(stderr, "Failed to create indices buffer.\n");
 	  exit(-1);
 	}
 
-	if (fread(ret, sizeof(cl_ulong), *num_indices, f) != *num_indices) {
+	if (fread(ret, sizeof(gpu_ulong), *num_indices, f) != *num_indices) {
 	  fprintf(stderr, "Failed to read indices file.\n");
 	  exit(-1);
 	}
@@ -1891,10 +1891,10 @@ int main(int ac, char **av) {
 
   rt_parameters rt_params = {0};
 
-  cl_platform_id platforms[MAX_NUM_PLATFORMS] = {0};
-  cl_device_id devices[MAX_NUM_DEVICES] = {0};
+  gpu_platform platforms[MAX_NUM_PLATFORMS] = {0};
+  gpu_device devices[MAX_NUM_DEVICES] = {0};
 
-  cl_uint num_platforms = 0, num_devices = 0;
+  gpu_uint num_platforms = 0, num_devices = 0;
 
   precomputed_and_potential_indices *ppi_head = NULL, *ppi_cur = NULL;
 

--- a/crackalack_unit_tests.c
+++ b/crackalack_unit_tests.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "shared.h"
 #include "test_chain.h"
@@ -40,13 +40,13 @@
 
 
 int main(int ac, char **av) {
-  cl_platform_id platforms[MAX_NUM_PLATFORMS];
-  cl_device_id devices[MAX_NUM_DEVICES];
-  cl_context context;
-  cl_program program;
-  cl_kernel kernel;
+  gpu_platform platforms[MAX_NUM_PLATFORMS];
+  gpu_device devices[MAX_NUM_DEVICES];
+  gpu_context context;
+  gpu_program program;
+  gpu_kernel kernel;
   int err = 0;
-  cl_uint num_platforms = 0, num_devices = 0;
+  gpu_uint num_platforms = 0, num_devices = 0;
 
   int ret = 0;
   unsigned int hash_type = HASH_UNDEFINED, all_tests_passed = 1;
@@ -60,11 +60,7 @@ int main(int ac, char **av) {
 #endif
   get_platforms_and_devices(-1, MAX_NUM_PLATFORMS, platforms, &num_platforms, MAX_NUM_DEVICES, devices, &num_devices, 1);
 
-  context = rc_clCreateContext(NULL, num_devices, devices, context_callback, NULL, &err);
-  if (err < 0) {
-    fprintf(stderr, "Failed to create context: %d\n", err);
-    exit(-1);
-  }
+  context = CLCREATECONTEXT(context_callback, &(devices[0]));
 
 
   /* PRNG test */

--- a/gpu_backend.h
+++ b/gpu_backend.h
@@ -1,0 +1,63 @@
+#ifndef _GPU_BACKEND_H
+#define _GPU_BACKEND_H
+
+/*
+ * Thin GPU backend selector (Option A).
+ *
+ * This header does NOT redeclare the rc_cl* wrapper externs or the CL*
+ * dispatch macros (CL_RO/WO/RW, CLCREATEARG, CLCREATECONTEXT, CLCREATEQUEUE,
+ * CLRUNKERNEL, CLREADBUFFER, CLFREEBUFFER, CLWAIT, CLFLUSH, etc.).  Those
+ * remain the property of the backend-specific setup header included below.
+ *
+ * Its only job is to (a) select a backend and (b) expose backend-neutral
+ * gpu_* type names so host code can be written once and compiled against any
+ * backend.  Under the default OpenCL build the gpu_* types are plain typedefs
+ * to the existing cl_* types, so the compiled result is byte-for-byte
+ * identical to the pre-refactor OpenCL build.
+ */
+
+#ifdef USE_CUDA
+
+/* CUDA backend (arrives in PR-B).  cuda_setup.h defines the gpu_* types,
+ * the dispatch macros, and the rc_* / gpu_* function layer. */
+#include "cuda_setup.h"
+
+#elif defined(USE_METAL)
+
+/* Metal backend (not part of this PR).  metal_setup.h would define the
+ * gpu_* types and dispatch macros. */
+#include "metal_setup.h"
+
+#else /* default: OpenCL backend */
+
+#include "opencl_setup.h"
+
+/* Neutral GPU type names mapped to the OpenCL cl_* equivalents.  Names match
+ * bandrel's gpu_backend.h so PR-B's CUDA/Metal typedefs drop in unchanged. */
+typedef cl_platform_id   gpu_platform;
+typedef cl_device_id     gpu_device;
+typedef cl_context       gpu_context;
+typedef cl_command_queue gpu_queue;
+typedef cl_mem           gpu_buffer;
+typedef cl_program       gpu_program;
+typedef cl_kernel        gpu_kernel;
+
+typedef cl_uint  gpu_uint;
+typedef cl_ulong gpu_ulong;
+typedef cl_int   gpu_int;
+typedef cl_bool  gpu_bool;
+
+/* Neutral memory-flag / status / bool constants.  Map to the OpenCL values.
+ * opencl_setup.h already defines CL_RO/WO/RW; GPU_* are the neutral aliases. */
+#define GPU_RO CL_RO
+#define GPU_WO CL_WO
+#define GPU_RW CL_RW
+
+#define GPU_TRUE  CL_TRUE
+#define GPU_FALSE CL_FALSE
+
+#define GPU_SUCCESS CL_SUCCESS
+
+#endif /* backend selection */
+
+#endif /* _GPU_BACKEND_H */

--- a/gws.c
+++ b/gws.c
@@ -1,12 +1,12 @@
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "gws.h"
 
 
 /* Given a GPU device, returns the optimal GWS setting (found through manual experimentation).  Returns 0 if the optimal setting on the device is unknown. */
-unsigned int get_optimal_gws(cl_device_id device) {
+unsigned int get_optimal_gws(gpu_device device) {
   char vendor[128] = {0}, name[64] = {0};
 
 

--- a/gws.h
+++ b/gws.h
@@ -1,6 +1,8 @@
 #ifndef _GWS_H
 #define _GWS_H
 
-unsigned int get_optimal_gws(cl_device_id device);
+#include "gpu_backend.h"
+
+unsigned int get_optimal_gws(gpu_device device);
 
 #endif

--- a/hash_validate.c
+++ b/hash_validate.c
@@ -20,7 +20,7 @@
 #include "shared.h"
 
 
-cl_uint hash_str_to_type(char *hash_str) {
+gpu_uint hash_str_to_type(char *hash_str) {
   unsigned int ret = HASH_UNDEFINED;
 
 

--- a/hash_validate.h
+++ b/hash_validate.h
@@ -1,9 +1,8 @@
 #ifndef _HASH_VALIDATE_H
 #define _HASH_VALIDATE_H
 
-#include "opencl_setup.h"
-#include <CL/cl.h>
+#include "gpu_backend.h"
 
-cl_uint hash_str_to_type(char *hash_str);
+gpu_uint hash_str_to_type(char *hash_str);
 
 #endif

--- a/misc.c
+++ b/misc.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <stdarg.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "charset.h"
 #include "misc.h"

--- a/opencl_setup.c
+++ b/opencl_setup.c
@@ -450,3 +450,11 @@ void print_platform_info(cl_platform_id *platforms, cl_uint num_platforms) {
   }
   fflush(stdout);
 }
+
+/* Neutral device-release entry point.  gen.c calls gpu_release_device() so the
+ * same source compiles on OpenCL and CUDA.  On OpenCL this simply wraps
+ * rc_clReleaseDevice; the CUDA backend provides its own (no-op) definition. */
+void gpu_release_device(cl_device_id device) {
+  if (device != NULL)
+    rc_clReleaseDevice(device);
+}

--- a/opencl_setup.h
+++ b/opencl_setup.h
@@ -120,5 +120,6 @@ void get_platform_str(cl_platform_id device, cl_platform_info param, char *buf, 
 void load_kernel(cl_context context, cl_uint num_devices, const cl_device_id *devices, const char *path, const char *kernel_name, cl_program *program, cl_kernel *kernel, unsigned int hash_type);
 void print_device_info(cl_device_id *devices, cl_uint num_devices);
 void print_platform_info(cl_platform_id *platforms, cl_uint num_platforms);
+void gpu_release_device(cl_device_id device);
 
 #endif

--- a/test_chain.c
+++ b/test_chain.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "cpu_rt_functions.h"
 #include "misc.h"
@@ -88,16 +88,16 @@ int cpu_test_chain(char *charset, unsigned int plaintext_len_min, unsigned int p
 
 
 /* Test a chain using the GPU. */
-int gpu_test_chain(cl_device_id device, cl_context context, cl_kernel kernel, char *charset, unsigned int plaintext_len_min, unsigned int plaintext_len_max, unsigned int table_index, unsigned int chain_len, uint64_t start, uint64_t expected_end) {
+int gpu_test_chain(gpu_device device, gpu_context context, gpu_kernel kernel, char *charset, unsigned int plaintext_len_min, unsigned int plaintext_len_max, unsigned int table_index, unsigned int chain_len, uint64_t start, uint64_t expected_end) {
   CLMAKETESTVARS();
 
   int test_passed = 0;
 
-  cl_mem charset_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, table_index_buffer = NULL, chain_len_buffer = NULL, start_buffer = NULL, end_buffer = NULL, debug_buffer = NULL;
+  gpu_buffer charset_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, table_index_buffer = NULL, chain_len_buffer = NULL, start_buffer = NULL, end_buffer = NULL, debug_buffer = NULL;
 
   unsigned char *debug_ptr = NULL;
-  cl_ulong *end_ptr = NULL;
-  cl_ulong end = 0;
+  gpu_ulong *end_ptr = NULL;
+  gpu_ulong end = 0;
 
 
   queue = CLCREATEQUEUE(context, device);
@@ -115,13 +115,13 @@ int gpu_test_chain(cl_device_id device, cl_context context, cl_kernel kernel, ch
   CLFLUSH(queue);
   CLWAIT(queue); 
 
-  end_ptr = calloc(1, sizeof(cl_ulong));
+  end_ptr = calloc(1, sizeof(gpu_ulong));
   if (end_ptr == NULL) {
     fprintf(stderr, "Error while creating output buffer.\n");
     exit(-1);
   }
 
-  CLREADBUFFER(end_buffer, sizeof(cl_ulong), end_ptr);
+  CLREADBUFFER(end_buffer, sizeof(gpu_ulong), end_ptr);
 
   if (*end_ptr == expected_end)
     test_passed = 1;
@@ -153,7 +153,7 @@ int gpu_test_chain(cl_device_id device, cl_context context, cl_kernel kernel, ch
 }
 
 
-int test_chain(cl_device_id device, cl_context context, cl_kernel kernel, unsigned int hash_type) {
+int test_chain(gpu_device device, gpu_context context, gpu_kernel kernel, unsigned int hash_type) {
   int tests_passed = 1;
   unsigned int i = 0;
 

--- a/test_chain.h
+++ b/test_chain.h
@@ -1,6 +1,6 @@
 #ifndef TEST_CHAIN_H
 #define TEST_CHAIN_H
 
-int test_chain(cl_device_id device, cl_context context, cl_kernel kernel, unsigned int hash_type);
+int test_chain(gpu_device device, gpu_context context, gpu_kernel kernel, unsigned int hash_type);
 
 #endif

--- a/test_chain_ntlm9.c
+++ b/test_chain_ntlm9.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "cpu_rt_functions.h"
 #include "misc.h"
@@ -63,16 +63,16 @@ int cpu_test_chain_ntlm9(uint64_t start, uint64_t expected_end) {
 
 
 /* Test a chain using the GPU. */
-int gpu_test_chain_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel, uint64_t start, uint64_t expected_end) {
+int gpu_test_chain_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel, uint64_t start, uint64_t expected_end) {
   CLMAKETESTVARS();
   int test_passed = 0;
-  cl_mem start_buffer = NULL, chain_len_buffer = NULL, pos_start_buffer = NULL;
-  cl_ulong end = 0;
-  cl_mem unused1 = NULL, unused2 = NULL, unused3 = NULL, unused4 = NULL, unused5 = NULL;
-  cl_uint unused_int = 0;
+  gpu_buffer start_buffer = NULL, chain_len_buffer = NULL, pos_start_buffer = NULL;
+  gpu_ulong end = 0;
+  gpu_buffer unused1 = NULL, unused2 = NULL, unused3 = NULL, unused4 = NULL, unused5 = NULL;
+  gpu_uint unused_int = 0;
   char unused_char[16] = {0};
-  cl_ulong *start_array = NULL, *end_array = NULL;
-  cl_uint chain_len = 803000, pos_start = 0;
+  gpu_ulong *start_array = NULL, *end_array = NULL;
+  gpu_uint chain_len = 803000, pos_start = 0;
 
 
   queue = CLCREATEQUEUE(context, device);
@@ -83,8 +83,8 @@ int gpu_test_chain_ntlm9(cl_device_id device, cl_context context, cl_kernel kern
   CLCREATEARG(2, end_buffer, CL_WO, end, sizeof(end));
   */
 
-  start_array = calloc(1, sizeof(cl_ulong));
-  end_array = calloc(1, sizeof(cl_ulong));
+  start_array = calloc(1, sizeof(gpu_ulong));
+  end_array = calloc(1, sizeof(gpu_ulong));
   if ((start_array == NULL) || (end_array == NULL)) {
     fprintf(stderr, "Error while allocating start & end arrays.\n");
     exit(-1);
@@ -98,15 +98,15 @@ int gpu_test_chain_ntlm9(cl_device_id device, cl_context context, cl_kernel kern
   CLCREATEARG(2, unused3, CL_RO, unused_int, sizeof(unused_int));
   CLCREATEARG(3, unused4, CL_RO, unused_int, sizeof(unused_int));
   CLCREATEARG(4, unused5, CL_RO, unused_int, sizeof(unused_int));
-  CLCREATEARG(5, chain_len_buffer, CL_RO, chain_len, sizeof(cl_uint));
-  CLCREATEARG_ARRAY(6, start_buffer, CL_RW, start_array, 1 * sizeof(cl_ulong));
-  CLCREATEARG(7, pos_start_buffer, CL_RO, pos_start, sizeof(cl_uint));
+  CLCREATEARG(5, chain_len_buffer, CL_RO, chain_len, sizeof(gpu_uint));
+  CLCREATEARG_ARRAY(6, start_buffer, CL_RW, start_array, 1 * sizeof(gpu_ulong));
+  CLCREATEARG(7, pos_start_buffer, CL_RO, pos_start, sizeof(gpu_uint));
 
   CLRUNKERNEL(queue, kernel, &global_work_size);
   CLFLUSH(queue);
   CLWAIT(queue); 
 
-  CLREADBUFFER(start_buffer, 1 * sizeof(cl_ulong), end_array);
+  CLREADBUFFER(start_buffer, 1 * sizeof(gpu_ulong), end_array);
 
 
   if (end_array[0] == expected_end)
@@ -130,7 +130,7 @@ int gpu_test_chain_ntlm9(cl_device_id device, cl_context context, cl_kernel kern
 }
 
 
-int test_chain_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel) {
+int test_chain_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel) {
   int tests_passed = 1;
   unsigned int i = 0;
 

--- a/test_chain_ntlm9.h
+++ b/test_chain_ntlm9.h
@@ -1,6 +1,6 @@
 #ifndef TEST_CHAIN_NTLM9_H
 #define TEST_CHAIN_NTLM9_H
 
-int test_chain_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel);
+int test_chain_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel);
 
 #endif

--- a/test_des.c
+++ b/test_des.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <CL/cl.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 #include "test_des.h"
 
 
@@ -43,12 +43,12 @@ struct des_test des_tests[] = {
 };
 
 
-int _test_des(cl_device_id device, cl_context context, cl_kernel kernel, unsigned char *plaintext, unsigned char *testkey, unsigned char *ciphertext) {
+int _test_des(gpu_device device, gpu_context context, gpu_kernel kernel, unsigned char *plaintext, unsigned char *testkey, unsigned char *ciphertext) {
   CLMAKETESTVARS();
   int test_passed = 0;
 
-  cl_mem input_buffer = NULL, key_buffer = NULL, output_buffer = NULL;
-  cl_mem debug_buffer = NULL;
+  gpu_buffer input_buffer = NULL, key_buffer = NULL, output_buffer = NULL;
+  gpu_buffer debug_buffer = NULL;
 
   unsigned char *input = NULL, *key = NULL, *output = NULL;
   unsigned int *debug = NULL;
@@ -130,7 +130,7 @@ int _test_des(cl_device_id device, cl_context context, cl_kernel kernel, unsigne
 }
 
 
-int test_des(cl_device_id device, cl_context context, cl_kernel kernel) {
+int test_des(gpu_device device, gpu_context context, gpu_kernel kernel) {
   int tests_passed = 1;
   unsigned int i = 0;
 

--- a/test_des.c
+++ b/test_des.c
@@ -17,7 +17,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <CL/cl.h>
 
 #include "gpu_backend.h"
 #include "test_des.h"

--- a/test_des.h
+++ b/test_des.h
@@ -1,6 +1,6 @@
 #ifndef TEST_DES_H
 #define TEST_DES_H
 
-int test_des(cl_device_id device, cl_context context, cl_kernel kernel);
+int test_des(gpu_device device, gpu_context context, gpu_kernel kernel);
 
 #endif

--- a/test_hash.c
+++ b/test_hash.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "cpu_rt_functions.h"
 #include "misc.h"
@@ -83,7 +83,7 @@ int cpu_test_hash_ntlm(char *input, char *expected_output_hex) {
 
 
 /* Creates and tests a hash using the GPU. */
-int gpu_test_hash(cl_device_id device, cl_context context, cl_kernel kernel, char *_input, char *expected_output_hex) {
+int gpu_test_hash(gpu_device device, gpu_context context, gpu_kernel kernel, char *_input, char *expected_output_hex) {
   CLMAKETESTVARS();
   int test_passed = 0;
   int i = 0;
@@ -91,14 +91,14 @@ int gpu_test_hash(cl_device_id device, cl_context context, cl_kernel kernel, cha
   unsigned char expected_output[32] = {0};
   unsigned int expected_output_len = 0;
 
-  cl_mem alg_buffer = NULL, input_buffer = NULL, input_len_buffer = NULL, output_buffer = NULL, output_len_buffer = NULL, debug_buffer = NULL;
+  gpu_buffer alg_buffer = NULL, input_buffer = NULL, input_len_buffer = NULL, output_buffer = NULL, output_len_buffer = NULL, debug_buffer = NULL;
 
   char *input = NULL;
   unsigned char *output = NULL, *debug_ptr = NULL;
   /*unsigned int *debug_ptr = NULL;*/
   
-  cl_uint hash_type = HASH_UNDEFINED;
-  cl_uint input_len = 0, output_len = 0;
+  gpu_uint hash_type = HASH_UNDEFINED;
+  gpu_uint input_len = 0, output_len = 0;
 
 
   queue = CLCREATEQUEUE(context, device);
@@ -124,9 +124,9 @@ int gpu_test_hash(cl_device_id device, cl_context context, cl_kernel kernel, cha
 
   CLCREATEARG(0, alg_buffer, CL_RO, hash_type, sizeof(hash_type));
   CLCREATEARG_ARRAY(1, input_buffer, CL_RO, input, strlen(input) + 1);
-  CLCREATEARG(2, input_len_buffer, CL_RO, input_len, sizeof(cl_uint));
+  CLCREATEARG(2, input_len_buffer, CL_RO, input_len, sizeof(gpu_uint));
   CLCREATEARG_ARRAY(3, output_buffer, CL_WO, output, MAX_HASH_OUTPUT_LEN);
-  CLCREATEARG(4, output_len_buffer, CL_WO, output_len, sizeof(cl_uint));
+  CLCREATEARG(4, output_len_buffer, CL_WO, output_len, sizeof(gpu_uint));
   CLCREATEARG_DEBUG(5, debug_buffer, debug_ptr);
   /*CLCREATEARG_ARRAY(5, debug_buffer, CL_WO, debug_ptr, DEBUG_LEN * sizeof(unsigned int));*/
 
@@ -135,7 +135,7 @@ int gpu_test_hash(cl_device_id device, cl_context context, cl_kernel kernel, cha
   CLWAIT(queue);
 
   CLREADBUFFER(output_buffer, MAX_HASH_OUTPUT_LEN, output);
-  CLREADBUFFER(output_len_buffer, sizeof(cl_uint), &output_len);
+  CLREADBUFFER(output_len_buffer, sizeof(gpu_uint), &output_len);
   CLREADBUFFER(debug_buffer, DEBUG_LEN, debug_ptr);
 
   expected_output_len = hex_to_bytes(expected_output_hex, sizeof(expected_output), expected_output);
@@ -168,7 +168,7 @@ int gpu_test_hash(cl_device_id device, cl_context context, cl_kernel kernel, cha
 }
 
 
-int test_hash(cl_device_id device, cl_context context, cl_kernel kernel, unsigned int hash_type) {
+int test_hash(gpu_device device, gpu_context context, gpu_kernel kernel, unsigned int hash_type) {
   int tests_passed = 1;
   unsigned int i = 0;
 

--- a/test_hash.h
+++ b/test_hash.h
@@ -1,6 +1,6 @@
 #ifndef TEST_HASH_H
 #define TEST_HASH_H
 
-int test_hash(cl_device_id device, cl_context context, cl_kernel kernel, unsigned int hash_type);
+int test_hash(gpu_device device, gpu_context context, gpu_kernel kernel, unsigned int hash_type);
 
 #endif

--- a/test_hash_ntlm9.c
+++ b/test_hash_ntlm9.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "cpu_rt_functions.h"
 #include "misc.h"
@@ -61,7 +61,7 @@ int cpu_test_hash_ntlm9(char *input, char *expected_output_hex) {
 
 
 /* Creates and tests a hash using the GPU. */
-int gpu_test_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel, char *_input, char *expected_output_hex) {
+int gpu_test_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel, char *_input, char *expected_output_hex) {
   CLMAKETESTVARS();
   int test_passed = 0;
   int i = 0;
@@ -69,10 +69,10 @@ int gpu_test_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel, ch
   unsigned char expected_output[32] = {0};
   /*unsigned int expected_output_len = 0;*/
 
-  cl_mem input_buffer = NULL, output_buffer = NULL;
+  gpu_buffer input_buffer = NULL, output_buffer = NULL;
 
   char *input = NULL;
-  cl_ulong output = 0;
+  gpu_ulong output = 0;
   unsigned char actual_output[8] = {0};
 
 
@@ -85,13 +85,13 @@ int gpu_test_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel, ch
   }
 
   CLCREATEARG_ARRAY(0, input_buffer, CL_RO, input, strlen(input) + 1);
-  CLCREATEARG(1, output_buffer, CL_WO, output, sizeof(cl_ulong));
+  CLCREATEARG(1, output_buffer, CL_WO, output, sizeof(gpu_ulong));
  
   CLRUNKERNEL(queue, kernel, &global_work_size);
   CLFLUSH(queue);
   CLWAIT(queue);
 
-  CLREADBUFFER(output_buffer, sizeof(cl_ulong), &output);
+  CLREADBUFFER(output_buffer, sizeof(gpu_ulong), &output);
 
   /*
   hash[i++] = ((output[0] >> 0) & 0xff);
@@ -136,7 +136,7 @@ int gpu_test_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel, ch
 }
 
 
-int test_hash_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel) {
+int test_hash_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel) {
   int tests_passed = 1;
   unsigned int i = 0;
 

--- a/test_hash_ntlm9.h
+++ b/test_hash_ntlm9.h
@@ -1,6 +1,6 @@
 #ifndef TEST_HASH_NTLM9_H
 #define TEST_HASH_NTLM9_H
 
-int test_hash_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel);
+int test_hash_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel);
 
 #endif

--- a/test_hash_to_index.c
+++ b/test_hash_to_index.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "cpu_rt_functions.h"
 #include "misc.h"
@@ -70,19 +70,19 @@ int cpu_test_h2i(char *hash_hex, uint64_t plaintext_space_total, unsigned int ta
 }
 
 
-int gpu_test_h2i(cl_device_id device, cl_context context, cl_kernel kernel, char *hash_hex, unsigned int charset_len, unsigned int plaintext_len_min, unsigned int plaintext_len_max, unsigned int table_index, unsigned int pos, uint64_t expected_index) {
+int gpu_test_h2i(gpu_device device, gpu_context context, gpu_kernel kernel, char *hash_hex, unsigned int charset_len, unsigned int plaintext_len_min, unsigned int plaintext_len_max, unsigned int table_index, unsigned int pos, uint64_t expected_index) {
   CLMAKETESTVARS();
 
   int test_passed = 0;
 
-  cl_mem hash_buffer = NULL, hash_len_buffer = NULL, charset_len_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, table_index_buffer = NULL, pos_buffer = NULL, index_buffer = NULL, debug_buffer = NULL;
+  gpu_buffer hash_buffer = NULL, hash_len_buffer = NULL, charset_len_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, table_index_buffer = NULL, pos_buffer = NULL, index_buffer = NULL, debug_buffer = NULL;
 
   unsigned char hash[MAX_HASH_OUTPUT_LEN] = {0};
   unsigned int hash_len = 0;
-  cl_ulong index = 0;
+  gpu_ulong index = 0;
 
   unsigned char *debug_ptr = NULL;
-  cl_ulong *index_ptr = NULL;
+  gpu_ulong *index_ptr = NULL;
 
   queue = CLCREATEQUEUE(context, device);
 
@@ -101,13 +101,13 @@ int gpu_test_h2i(cl_device_id device, cl_context context, cl_kernel kernel, char
   CLFLUSH(queue);
   CLWAIT(queue); 
 
-  index_ptr = calloc(1, sizeof(cl_ulong));
+  index_ptr = calloc(1, sizeof(gpu_ulong));
   if (index_ptr == NULL) {
     fprintf(stderr, "Error while creating output buffer.\n");
     exit(-1);
   }
 
-  CLREADBUFFER(index_buffer, sizeof(cl_ulong), index_ptr);
+  CLREADBUFFER(index_buffer, sizeof(gpu_ulong), index_ptr);
 
   if (*index_ptr == expected_index)
     test_passed = 1;
@@ -139,7 +139,7 @@ int gpu_test_h2i(cl_device_id device, cl_context context, cl_kernel kernel, char
   return test_passed;
 }
 
-int test_h2i(cl_device_id device, cl_context context, cl_kernel kernel, unsigned int hash_type) {
+int test_h2i(gpu_device device, gpu_context context, gpu_kernel kernel, unsigned int hash_type) {
   int tests_passed = 1;
   unsigned int i = 0;
   uint64_t plaintext_space_total = 0;

--- a/test_hash_to_index.h
+++ b/test_hash_to_index.h
@@ -1,6 +1,6 @@
 #ifndef TEST_HASH_TO_INDEX_H
 #define TEST_HASH_TO_INDEX_H
 
-int test_h2i(cl_device_id device, cl_context context, cl_kernel kernel, unsigned int hash_type);
+int test_h2i(gpu_device device, gpu_context context, gpu_kernel kernel, unsigned int hash_type);
 
 #endif

--- a/test_hash_to_index_ntlm9.c
+++ b/test_hash_to_index_ntlm9.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "cpu_rt_functions.h"
 #include "misc.h"
@@ -56,12 +56,12 @@ int cpu_test_h2i_ntlm9(char *hash_hex, uint64_t plaintext_space_total, unsigned 
 }
 
 
-int gpu_test_h2i_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel, char *hash_hex, unsigned int pos, uint64_t expected_index) {
+int gpu_test_h2i_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel, char *hash_hex, unsigned int pos, uint64_t expected_index) {
   CLMAKETESTVARS();
   int test_passed = 0;
-  cl_mem hash_buffer = NULL, pos_buffer = NULL, index_buffer = NULL;
-  cl_ulong hash_long = 0;
-  cl_ulong index = 0;
+  gpu_buffer hash_buffer = NULL, pos_buffer = NULL, index_buffer = NULL;
+  gpu_ulong hash_long = 0;
+  gpu_ulong index = 0;
   unsigned char hash[MAX_HASH_OUTPUT_LEN] = {0};
 
 
@@ -94,7 +94,7 @@ int gpu_test_h2i_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel
   CLFLUSH(queue);
   CLWAIT(queue); 
 
-  CLREADBUFFER(index_buffer, sizeof(cl_ulong), &index);
+  CLREADBUFFER(index_buffer, sizeof(gpu_ulong), &index);
 
 
   if (index == expected_index)
@@ -111,7 +111,7 @@ int gpu_test_h2i_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel
   return test_passed;
 }
 
-int test_h2i_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel) {
+int test_h2i_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel) {
   int tests_passed = 1;
   unsigned int i = 0;
   uint64_t plaintext_space_total = 0;

--- a/test_hash_to_index_ntlm9.h
+++ b/test_hash_to_index_ntlm9.h
@@ -1,6 +1,6 @@
 #ifndef TEST_HASH_TO_INDEX_NTLM9_H
 #define TEST_HASH_TO_INDEX_NTLM9_H
 
-int test_h2i_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel);
+int test_h2i_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel);
 
 #endif

--- a/test_index_to_plaintext.c
+++ b/test_index_to_plaintext.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "cpu_rt_functions.h"
 #include "misc.h"
@@ -29,9 +29,9 @@
 
 struct i2p_test {
   char charset[MAX_CHARSET_LEN];
-  cl_uint plaintext_len_min;
-  cl_uint plaintext_len_max;
-  cl_ulong index;
+  gpu_uint plaintext_len_min;
+  gpu_uint plaintext_len_max;
+  gpu_ulong index;
   char expected_plaintext[MAX_PLAINTEXT_LEN];
 };
 
@@ -55,7 +55,7 @@ struct i2p_test i2p_tests[] = {
 };
 
 
-int cpu_test_index_to_plaintext(char *charset, cl_uint plaintext_len_min, cl_uint plaintext_len_max, cl_ulong index, char *expected_plaintext) {
+int cpu_test_index_to_plaintext(char *charset, gpu_uint plaintext_len_min, gpu_uint plaintext_len_max, gpu_ulong index, char *expected_plaintext) {
   uint64_t plaintext_space_up_to_index[MAX_PLAINTEXT_LEN] = {0};
   char computed_plaintext[MAX_PLAINTEXT_LEN] = {0};
   unsigned int computed_plaintext_len = 0;
@@ -73,17 +73,17 @@ int cpu_test_index_to_plaintext(char *charset, cl_uint plaintext_len_min, cl_uin
 }
 
 
-int gpu_test_index_to_plaintext(cl_device_id device, cl_context context, cl_kernel kernel, char *charset, cl_uint plaintext_len_min, cl_uint plaintext_len_max, cl_ulong index, char *expected_plaintext) {
+int gpu_test_index_to_plaintext(gpu_device device, gpu_context context, gpu_kernel kernel, char *charset, gpu_uint plaintext_len_min, gpu_uint plaintext_len_max, gpu_ulong index, char *expected_plaintext) {
   CLMAKETESTVARS();
   int test_passed = 0;
 
-  cl_mem charset_buffer = NULL, charset_len_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, index_buffer = NULL, plaintext_buffer = NULL, plaintext_len_buffer = NULL, debug_buffer = NULL;
+  gpu_buffer charset_buffer = NULL, charset_len_buffer = NULL, plaintext_len_min_buffer = NULL, plaintext_len_max_buffer = NULL, index_buffer = NULL, plaintext_buffer = NULL, plaintext_len_buffer = NULL, debug_buffer = NULL;
 
   unsigned char *plaintext = NULL;
   unsigned char *debug_ptr = NULL;
 
-  cl_uint charset_len = strlen(charset);
-  cl_uint plaintext_len = MAX_PLAINTEXT_LEN;
+  gpu_uint charset_len = strlen(charset);
+  gpu_uint plaintext_len = MAX_PLAINTEXT_LEN;
 
 
   queue = CLCREATEQUEUE(context, device);
@@ -95,12 +95,12 @@ int gpu_test_index_to_plaintext(cl_device_id device, cl_context context, cl_kern
   }
 
   CLCREATEARG_ARRAY(0, charset_buffer, CL_RO, charset, strlen(charset) + 1);
-  CLCREATEARG(1, charset_len_buffer, CL_RO, charset_len, sizeof(cl_uint));
-  CLCREATEARG(2, plaintext_len_min_buffer, CL_RO, plaintext_len_min, sizeof(cl_uint));
-  CLCREATEARG(3, plaintext_len_max_buffer, CL_RO, plaintext_len_max, sizeof(cl_uint));
-  CLCREATEARG(4, index_buffer, CL_RO, index, sizeof(cl_ulong));
+  CLCREATEARG(1, charset_len_buffer, CL_RO, charset_len, sizeof(gpu_uint));
+  CLCREATEARG(2, plaintext_len_min_buffer, CL_RO, plaintext_len_min, sizeof(gpu_uint));
+  CLCREATEARG(3, plaintext_len_max_buffer, CL_RO, plaintext_len_max, sizeof(gpu_uint));
+  CLCREATEARG(4, index_buffer, CL_RO, index, sizeof(gpu_ulong));
   CLCREATEARG_ARRAY(5, plaintext_buffer, CL_WO, plaintext, MAX_PLAINTEXT_LEN);
-  CLCREATEARG(6, plaintext_len_buffer, CL_WO, plaintext_len, sizeof(cl_uint));
+  CLCREATEARG(6, plaintext_len_buffer, CL_WO, plaintext_len, sizeof(gpu_uint));
   CLCREATEARG_DEBUG(7, debug_buffer, debug_ptr);
 
   CLRUNKERNEL(queue, kernel, &global_work_size);
@@ -108,7 +108,7 @@ int gpu_test_index_to_plaintext(cl_device_id device, cl_context context, cl_kern
   CLWAIT(queue);
 
   CLREADBUFFER(plaintext_buffer, MAX_PLAINTEXT_LEN, plaintext);
-  CLREADBUFFER(plaintext_len_buffer, sizeof(cl_uint), &plaintext_len);
+  CLREADBUFFER(plaintext_len_buffer, sizeof(gpu_uint), &plaintext_len);
   CLREADBUFFER(debug_buffer, DEBUG_LEN, debug_ptr);
 
   /*
@@ -142,7 +142,7 @@ int gpu_test_index_to_plaintext(cl_device_id device, cl_context context, cl_kern
 }
 
 
-int test_index_to_plaintext(cl_device_id device, cl_context context, cl_kernel kernel) {
+int test_index_to_plaintext(gpu_device device, gpu_context context, gpu_kernel kernel) {
   int tests_passed = 1;
   unsigned int i = 0;
 

--- a/test_index_to_plaintext.h
+++ b/test_index_to_plaintext.h
@@ -1,6 +1,6 @@
 #ifndef TEST_INDEX_TO_PLAINTEXT_H
 #define TEST_INDEX_TO_PLAINTEXT_H
 
-int test_index_to_plaintext(cl_device_id device, cl_context context, cl_kernel kernel);
+int test_index_to_plaintext(gpu_device device, gpu_context context, gpu_kernel kernel);
 
 #endif

--- a/test_index_to_plaintext_ntlm9.c
+++ b/test_index_to_plaintext_ntlm9.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "opencl_setup.h"
+#include "gpu_backend.h"
 
 #include "cpu_rt_functions.h"
 #include "misc.h"
@@ -28,7 +28,7 @@
 #include "test_index_to_plaintext_ntlm9.h"
 
 struct i2p_ntlm9_test {
-  cl_ulong index;
+  gpu_ulong index;
   char expected_plaintext[MAX_PLAINTEXT_LEN];
 };
 
@@ -38,10 +38,10 @@ struct i2p_ntlm9_test i2p_ntlm9_tests[] = {
 
 
 
-int gpu_test_index_to_plaintext_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel, cl_ulong index, char *expected_plaintext) {
+int gpu_test_index_to_plaintext_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel, gpu_ulong index, char *expected_plaintext) {
   CLMAKETESTVARS();
   int test_passed = 0;
-  cl_mem index_buffer = NULL, plaintext_buffer = NULL;
+  gpu_buffer index_buffer = NULL, plaintext_buffer = NULL;
   unsigned char *plaintext = NULL;
 
 
@@ -53,7 +53,7 @@ int gpu_test_index_to_plaintext_ntlm9(cl_device_id device, cl_context context, c
     exit(-1);
   }
 
-  CLCREATEARG(0, index_buffer, CL_RO, index, sizeof(cl_ulong));
+  CLCREATEARG(0, index_buffer, CL_RO, index, sizeof(gpu_ulong));
   CLCREATEARG_ARRAY(1, plaintext_buffer, CL_WO, plaintext, MAX_PLAINTEXT_LEN);
 
   CLRUNKERNEL(queue, kernel, &global_work_size);
@@ -78,7 +78,7 @@ int gpu_test_index_to_plaintext_ntlm9(cl_device_id device, cl_context context, c
 }
 
 
-int test_index_to_plaintext_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel) {
+int test_index_to_plaintext_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel) {
   int tests_passed = 1;
   unsigned int i = 0;
 

--- a/test_index_to_plaintext_ntlm9.h
+++ b/test_index_to_plaintext_ntlm9.h
@@ -1,6 +1,6 @@
 #ifndef TEST_INDEX_TO_PLAINTEXT_NTLM9_H
 #define TEST_INDEX_TO_PLAINTEXT_NTLM9_H
 
-int test_index_to_plaintext_ntlm9(cl_device_id device, cl_context context, cl_kernel kernel);
+int test_index_to_plaintext_ntlm9(gpu_device device, gpu_context context, gpu_kernel kernel);
 
 #endif


### PR DESCRIPTION
> **Stack 1 of 3** — base of the CUDA-backend stack. PR-B (CUDA backend) and PR-C (regression harness) build on this. Review/merge in order.

# PR-A: Introduce a backend abstraction so a second GPU backend can be added

**Branch:** `feat/gpu-backend-abstraction` → `blurbdust/master`
**Type:** refactor, behavior-neutral on OpenCL. No new features, no new dependencies.
**Diff:** 30 files, +308/−238.

## Why

This is the first of a two-PR stack. On its own it adds no functionality — it reshapes the GPU plumbing so a non-OpenCL backend (CUDA, in the follow-up PR) can be selected at build time without touching every call site. Landing it in isolation keeps the follow-up CUDA PR small and reviewable.

I've split it out precisely so it can be evaluated on one question only: **does this change any OpenCL behavior?** The answer is no, and there's evidence below.

## What it does

- Adds `gpu_backend.h`: a thin backend *selector*. Default (and the only path this PR compiles) is `#include "opencl_setup.h"`; `#ifdef USE_CUDA`/`#elif USE_METAL` branches are stubs for later. It does **not** redeclare the existing `rc_cl*` wrappers or the `CL*` dispatch macros — those stay in `opencl_setup.h`, which remains the OpenCL backend.
- Under the OpenCL build, the neutral `gpu_*` types are plain typedefs to the existing `cl_*` types (`gpu_device` ← `cl_device_id`, `gpu_context` ← `cl_context`, etc.), so the compiled output is identical.
- Refactors host code (`crackalack_gen.c`, `crackalack_lookup.c`, `gws.c/.h`, the `test_*` files, `crackalack_unit_tests.c`, `hash_validate`, `misc.c`) to use the neutral `gpu_*` type names instead of raw `cl_*`.
- Adds a neutral `gpu_release_device()` wrapper in `opencl_setup.c` (OpenCL calls `clReleaseDevice`) so one host call site doesn't need a raw CL type.

## What it deliberately does NOT touch

- No change to the `rc_cl*` wrapper layer or the dispatch macros.
- **No launch-geometry change.** `CLRUNKERNEL` still passes `NULL` as the local-work-size to `clEnqueueNDRangeKernel`. This is called out because it's the one place a "cleanup" refactor could silently change performance — it doesn't.
- No feature code, no build-system change (`make linux` recipe untouched).

## Behavior-neutrality evidence

Built `make linux` before and after and ran `./crackalack_unit_tests`. Fingerprint is byte-identical:

```
NTLM  index_to_plaintext ... FAILED      NTLM9 index_to_plaintext ... passed
NTLM  hash ............... FAILED        NTLM9 hash ............... passed
NTLM  hash_to_index ...... passed        NTLM9 hash_to_index ...... passed
NTLM  chain .............. FAILED        NTLM9 chain .............. passed
Some unit tests failed!  :(
```

> Note: the three `NTLM` (non-NTLM9) failures are **pre-existing on current `master`** — they reproduce on an unmodified checkout at `532b527`. This PR does not change which tests pass or fail. (The follow-up CUDA PR actually *fixes* two of them — see PR-B.)

## Review focus

Every hunk is one of: (a) the new `gpu_backend.h`, (b) a `cl_*` → `gpu_*` type rename, or (c) an `#include "opencl_setup.h"` → `#include "gpu_backend.h"` swap. If any hunk looks like it changes logic, control flow, buffer sizes, or call order, that's a bug — please flag it.
